### PR TITLE
Implement placeholder text for FakeCurrencyInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ It includes the same props of the CurrencyInput with the additional of the follo
 | ------------------------- | ---------- | ------- | ------------------------------------------------- |
 | **...CurrencuInputProps** |            |         | Inherit all [props of `CurrencyInput`](#props).   |
 | **`containerStyle`**      | style prop |         | Style for the container View that wraps the Text. |
-| **`caretColor`**          | string     | #6495ed | Color of the caret.                               |
+| **`caretColor`**          | string     | #6495ed | Color of the caret. Same as caretStyle.color.     |
+| **`caretStyle`**          | style prop |         | Style for the caret text component.               |
 
 <br>
 

--- a/src/FakeCurrencyInput.tsx
+++ b/src/FakeCurrencyInput.tsx
@@ -30,11 +30,11 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
     return (
       <View style={[containerStyle, styles.inputContainer]}>
         <TextWithCursor
-          style={style}
+          style={[style, {color: formattedValue ? style[0].color : props.placeholderTextColor}]}
           cursorVisible={focused && !caretHidden}
           cursorProps={{ style: { color: caretColor || selectionColor } }}
         >
-          {formattedValue}
+          {formattedValue ? formattedValue : props.placeholder}
         </TextWithCursor>
         <CurrencyInput
           value={value}

--- a/src/FakeCurrencyInput.tsx
+++ b/src/FakeCurrencyInput.tsx
@@ -26,11 +26,12 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
 
     const [focused, setFocused] = React.useState(false);
     const [formattedValue, setFormattedValue] = React.useState('');
+    const placeholderStyle = formattedValue ? {} : {color: props.placeholderTextColor};
 
     return (
       <View style={[containerStyle, styles.inputContainer]}>
         <TextWithCursor
-          style={[style, {color: formattedValue ? style && style.color : props.placeholderTextColor}]}
+          style={[style, placeholderStyle]}
           cursorVisible={focused && !caretHidden}
           cursorProps={{ style: { color: caretColor || selectionColor } }}
         >

--- a/src/FakeCurrencyInput.tsx
+++ b/src/FakeCurrencyInput.tsx
@@ -30,7 +30,7 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
     return (
       <View style={[containerStyle, styles.inputContainer]}>
         <TextWithCursor
-          style={[style, {color: formattedValue ? style && style[0].color : props.placeholderTextColor}]}
+          style={[style, {color: formattedValue ? style && style.color : props.placeholderTextColor}]}
           cursorVisible={focused && !caretHidden}
           cursorProps={{ style: { color: caretColor || selectionColor } }}
         >

--- a/src/FakeCurrencyInput.tsx
+++ b/src/FakeCurrencyInput.tsx
@@ -18,6 +18,7 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
       containerStyle,
       caretHidden,
       caretColor,
+      caretStyle,
       selectionColor,
       onFocus,
       onBlur,
@@ -33,7 +34,7 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
         <TextWithCursor
           style={[style, placeholderStyle]}
           cursorVisible={focused && !caretHidden}
-          cursorProps={{ style: { color: caretColor || selectionColor } }}
+          cursorProps={{ style: [{ color: caretColor || selectionColor }, caretStyle] }}
         >
           {formattedValue ? formattedValue : props.placeholder}
         </TextWithCursor>

--- a/src/FakeCurrencyInput.tsx
+++ b/src/FakeCurrencyInput.tsx
@@ -30,7 +30,7 @@ const FakeCurrencyInput = React.forwardRef<TextInput, FakeCurrencyInputProps>(
     return (
       <View style={[containerStyle, styles.inputContainer]}>
         <TextWithCursor
-          style={[style, {color: formattedValue ? style[0].color : props.placeholderTextColor}]}
+          style={[style, {color: formattedValue ? style && style[0].color : props.placeholderTextColor}]}
           cursorVisible={focused && !caretHidden}
           cursorProps={{ style: { color: caretColor || selectionColor } }}
         >

--- a/src/TextWithCursor.tsx
+++ b/src/TextWithCursor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, StyleSheet, Text, View} from 'react-native';
+import { StyleSheet, Text, View} from 'react-native';
 
 import type { TextWithCursorProps } from './props';
 import useBlink from './hooks/useBlink';

--- a/src/TextWithCursor.tsx
+++ b/src/TextWithCursor.tsx
@@ -33,35 +33,39 @@ const TextWithCursor = (textWithCursorProps: TextWithCursorProps) => {
   }, [children]);
 
   return (
-    <Text style={[styles.text, style]} {...rest}>
-      {children}
-      <View style={styles.cursorView}>
-        <Text
-          {...cursorProps}
-          style={[
-            {
-              fontSize: cursorFontSize * (cursorFontSize < 26 ? 1.42 : 1.25),
-            },
-            styles.cursor,
-            cursorProps?.style,
-            !cursorVisibility ? styles.cursorHidden : undefined,
-          ]}
-        >
-          |
-        </Text>
-      </View>
-    </Text>
+    <View style={styles.textWithCursorView}>
+      <Text style={[styles.text, style]} {...rest}>
+        {children}
+      </Text>
+      <Text
+        {...cursorProps}
+        style={[
+          {
+            fontSize: cursorFontSize * (cursorFontSize < 26 ? 1.42 : 1.25),
+          },
+          styles.cursor,
+          cursorProps?.style,
+          !cursorVisibility ? styles.cursorHidden : undefined,
+        ]}
+      >
+        |
+      </Text>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  textWithCursorView: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
   text: {
     fontSize: 18,
-    marginTop: -3.2,
   },
-  cursorView: {},
   cursor: {
     color: '#6495ed',
+    marginTop: -7,
+    marginLeft: -3,
   },
   cursorHidden: {
     color: 'transparent',

--- a/src/TextWithCursor.tsx
+++ b/src/TextWithCursor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text, View} from 'react-native';
+import { Platform, StyleSheet, Text, View} from 'react-native';
 
 import type { TextWithCursorProps } from './props';
 import useBlink from './hooks/useBlink';
@@ -35,20 +35,20 @@ const TextWithCursor = (textWithCursorProps: TextWithCursorProps) => {
   return (
     <Text style={[styles.text, style]} {...rest}>
       {children}
-    <View style={styles.cursorView}>
-      <Text
-        {...cursorProps}
-        style={[
-          {
-            fontSize: cursorFontSize * (cursorFontSize < 26 ? 1.42 : 1.25),
-          },
-          styles.cursor,
-          cursorProps?.style,
-          !cursorVisibility ? styles.cursorHidden : undefined,
-        ]}
-      >
-        |
-      </Text>
+      <View style={styles.cursorView}>
+        <Text
+          {...cursorProps}
+          style={[
+            {
+              fontSize: cursorFontSize * (cursorFontSize < 26 ? 1.42 : 1.25),
+            },
+            styles.cursor,
+            cursorProps?.style,
+            !cursorVisibility ? styles.cursorHidden : undefined,
+          ]}
+        >
+          |
+        </Text>
       </View>
     </Text>
   );
@@ -59,12 +59,11 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: -3.2,
   },
-  cursorView: {
-    marginTop: -3.2,
-  },
+  cursorView: {},
   cursor: {
     color: '#6495ed',
     marginLeft: -3.2,
+    top: Platform.OS === 'ios' ? 1 : 10,
   },
   cursorHidden: {
     color: 'transparent',

--- a/src/TextWithCursor.tsx
+++ b/src/TextWithCursor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text, View} from 'react-native';
 
 import type { TextWithCursorProps } from './props';
 import useBlink from './hooks/useBlink';
@@ -35,6 +35,7 @@ const TextWithCursor = (textWithCursorProps: TextWithCursorProps) => {
   return (
     <Text style={[styles.text, style]} {...rest}>
       {children}
+    <View style={styles.cursorView}>
       <Text
         {...cursorProps}
         style={[
@@ -48,6 +49,7 @@ const TextWithCursor = (textWithCursorProps: TextWithCursorProps) => {
       >
         |
       </Text>
+      </View>
     </Text>
   );
 };
@@ -57,8 +59,12 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: -3.2,
   },
+  cursorView: {
+    marginTop: -3.2,
+  },
   cursor: {
     color: '#6495ed',
+    marginLeft: -3.2,
   },
   cursorHidden: {
     color: 'transparent',

--- a/src/TextWithCursor.tsx
+++ b/src/TextWithCursor.tsx
@@ -62,8 +62,6 @@ const styles = StyleSheet.create({
   cursorView: {},
   cursor: {
     color: '#6495ed',
-    marginLeft: -3.2,
-    top: Platform.OS === 'ios' ? 1 : 10,
   },
   cursorHidden: {
     color: 'transparent',

--- a/src/props.ts
+++ b/src/props.ts
@@ -1,4 +1,4 @@
-import type { TextInputProps, StyleProp, ViewStyle, TextProps } from 'react-native';
+import type { TextInputProps, StyleProp, ViewStyle, TextProps, TextStyle } from 'react-native';
 
 export interface FormatNumberOptions {
   /**
@@ -120,7 +120,12 @@ export interface FakeCurrencyInputProps extends CurrencyInputProps {
    * Color of the caret. Defaults to #6495ed
    */
   caretColor?: string;
-}
+
+  /**
+   * Style for the caret text component
+   */
+   caretStyle?: StyleProp<TextStyle>;
+  }
 
 export interface TextWithCursorProps extends TextProps {
   children?: React.ReactNode;


### PR DESCRIPTION
Allow placeholder and placeholderTextColor to be used with FakeCurrencyInput. Also update position to move cursor slightly left to provide improved appearance.

Update - exposes caretStyle as well to refine desired caret presentation. Implementation is backward compatible with caretColor and caretHidden.